### PR TITLE
Increase disk size to 3 GB

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ dhcp-interface=vio0
 
 plugin=base/raw-image-file
 image-basename=openstack-openbsd${version}
-image-size=2
+image-size=3
 
 plugin=partitioner/disklabel
 plugin=package/cloud-init


### PR DESCRIPTION
With modern OpenBSD a 2 GB disk is too small. 
The kernel re-linking process will almost fill the disk and the system might become unusable.